### PR TITLE
Change to Es2015 module

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,6 @@
 {
-  "presets": ["es2015"]
+  "presets": ["es2015"],
+  "plugins": [
+    "add-module-exports"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "gulp test"
   },
   "devDependencies": {
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-polyfill": "^6.9.1",
     "babel-preset-es2015": "^6.9.0",
     "babelify": "^7.3.0",

--- a/samples/collatz-amd-module.html
+++ b/samples/collatz-amd-module.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Async: Collatz sample with AMD module</title>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.2/require.min.js"></script>
+  </head>
+  <body>
+    <h1>Threading</h1>
+    <h2>Samples</h2>
+    <h3>Longuest Collatz sequence</h3>
+    <form>
+      <label>
+        Threshold <input name="threshold" type="number" value="1000000">
+      </label>
+      <br>
+      <label>
+        Threads <input name="threads" type="number" value="8">
+      </label>
+      <br>
+      <button type="button">OK</button>
+      <br>
+      <label>
+        Answer <input name="answer" type="text" readonly>
+        in <input name="duration" type="text" readonly> ms
+      </label>
+    </form>
+    <script>
+      requirejs.config({
+          baseUrl: '../dist',
+          paths: {
+              async: 'async.min'
+          }
+      });
+
+      require(['async'], function(async){
+
+        var thresholdInput = document.getElementsByName('threshold')[0];
+        var threadsInput = document.getElementsByName('threads')[0];
+        var okButton = document.querySelector('button');
+        var answerInput = document.getElementsByName('answer')[0];
+        var durationInput = document.getElementsByName('duration')[0];
+
+
+        okButton.addEventListener('click', function () {
+          answerInput.value = null;
+          durationInput.value = null;
+
+          var threads = parseInt(threadsInput.value);
+          var threshold = parseInt(thresholdInput.value);
+          var ranges = createRanges(threshold, threads);
+          var startTime = Date.now();
+
+          var promises = ranges.map(function (r) {
+            return async(longestCollatz, null, [
+              r.begin,
+              r.end,
+              r.step
+            ]);
+          });
+
+          Promise.all(promises).then(function (results) {
+            var longest = {value: 0, count: 0};
+
+            results.forEach(function (r) {
+              if (r.count >  longest.count)
+                longest = r;
+            });
+
+            answerInput.value = longest.value;
+            durationInput.value = Date.now() - startTime;
+          });
+        });
+
+        function createRanges(threshold, threads) {
+          var ranges = [];
+
+          for (var i = 0; i < threads; i++) {
+            ranges.push({
+              begin: i + 1,
+              end: threshold,
+              step: threads
+            });
+          }
+
+          return ranges;
+        }
+
+        function longestCollatz(begin, end, step) {
+          var longest = {value: 0, count: 0};
+          var count, value;
+
+          function even(n) {
+            return n / 2;
+          }
+
+          function odd(n) {
+            return 3 * n + 1;
+          }
+
+          for (var n = begin; n <= end; n += step) {
+            value = n;
+            count = 0;
+
+            while (value !== 1) {
+              value = value % 2 ? odd(value) : even(value);
+              count++;
+            }
+
+            if (count > longest.count) {
+              longest.value = n;
+              longest.count = count;
+            }
+          }
+
+          return longest;
+        }
+
+      });
+
+    </script>
+  </body>
+</html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,4 +11,4 @@ const workerFactory = WorkerFactory(util, workerConstructor)
 const workerPool = WorkerPool(workerFactory)
 const async = Async(util, workerPool)
 
-export = async
+export default async

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2015",
-    "module": "commonjs",
+    "module": "es2015",
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
Hi,

I have changed your **tsconfig.json** to use **es2015** module instead of **commonjs**.  Then I changed how you exports your module in **main.ts**. Now it is exporting in es2015 format just like in the example below: 

`exports default async`

To **export default** in Babel 6 using the "standalone" option of browserify, you need also to install a plugin called **add-module-exports**:  
https://www.npmjs.com/package/babel-plugin-add-module-exports

Without this plugin a consumer would have to require **async** and access the "default" property just like in the example below: 

`var async = require("async").default;`

Also I have add a example of how to use async with an amd module (requirejs). 

I hope you like it :) 
